### PR TITLE
Add screenshotStrategy before:step and after:step

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you wish to override the default reporter configuration add a reporterOptions
 | 5.    | Set JPEG quality. Only relevant if `resize` option is `true`. The smaller the value, the smaller image size and quality would be. Default value is `70`. Max value allowed is `100`                    |
 | 6.    | Resize image. Default value is `false`                                                                                                                                                                 |
 | 7.    | value to decrease the total number of pixels by. Only relevant if `resize` option is true. Defaults to `1` Valid values `1 - 5`                                                                        |
-| 8.    | how often to take screenshots. Supported values are `on:error`, `before:click`, `none`. Defaults to `none`. `before:click` is a great option for creating a timeline of screenshots of app under test. |
+| 8.    | how often to take screenshots. Supported values are `on:error`, `before:click`, `before:step`, `after:step`, `none`. Defaults to `none`. `before:click` is a great option for creating a timeline of screenshots of app under test. `after:step` is a great option when using cucumber tests.|
 
 ### Add Additional information to test context
 

--- a/lib/timeline-service.ts
+++ b/lib/timeline-service.ts
@@ -19,6 +19,8 @@ const writeFilePromiseSync = promisify(writeFile);
 
 const BEFORE_CLICK = 'before:click';
 const ON_ERROR = 'on:error';
+const BEFORE_STEP = 'before:step'
+const AFTER_STEP = 'after:step'
 
 declare var browser: any;
 
@@ -41,7 +43,7 @@ export class TimelineService {
     );
     if (timelineFilter.length === 0) {
       throw new Error(
-        `Add timeline to reporters in wdio config: 
+        `Add timeline to reporters in wdio config:
             reporters: [[timeline]]
         `
       );
@@ -49,14 +51,14 @@ export class TimelineService {
     const timeline = timelineFilter[0];
     if (timeline.length !== 2 || typeof timeline[1] !== 'object') {
       throw new Error(
-        `Add reporter options object to timeline reporter: 
+        `Add reporter options object to timeline reporter:
             reporters: [[timeline, {}]]
         `
       );
     }
     if (!timeline[1].outputDir) {
       throw new Error(
-        `Set outputDir on reporter options object: 
+        `Set outputDir on reporter options object:
             reporters: [[timeline, {
               outputDir: 'desired_folder'
             }]]
@@ -103,6 +105,20 @@ export class TimelineService {
   beforeCommand(commandName) {
     const { screenshotStrategy } = this.reporterOptions;
     if (screenshotStrategy === BEFORE_CLICK && 'click' === commandName) {
+      browser.takeScreenshot();
+    }
+  }
+
+  beforeStep() {
+    const { screenshotStrategy } = this.reporterOptions;
+    if (screenshotStrategy === BEFORE_STEP) {
+      browser.takeScreenshot();
+    }
+  }
+
+  afterStep() {
+    const { screenshotStrategy } = this.reporterOptions;
+    if (screenshotStrategy === AFTER_STEP) {
       browser.takeScreenshot();
     }
   }


### PR DESCRIPTION
When using cucumber tests, it is convenient to take a picture at the
start or end of each test step showing the condition of the software
under test. This change adds new options for the screenshotStrategy
which allow the user to collect these screenshots.