### PR TITLE
Added validation to avoid JSON error due empty log

### DIFF
--- a/lib/timeline-service.ts
+++ b/lib/timeline-service.ts
@@ -167,8 +167,11 @@ export class TimelineService {
         .forEach(file => {
           let runnerResult;
           try {
-            const reportLog = `${this.resolvedOutputDir}/${file}`;
-            runnerResult = JSON.parse(readFileSync(reportLog).toString());
+            const reportLogPath = `${this.resolvedOutputDir}/${file}`;
+            const reportLog = readFileSync(reportLogPath).toString();
+            if (reportLog != ''){
+              runnerResult = JSON.parse(reportLog);
+            }
           } catch (error) {
             console.log(error);
           } finally {

--- a/lib/timeline-service.ts
+++ b/lib/timeline-service.ts
@@ -169,7 +169,7 @@ export class TimelineService {
           try {
             const reportLogPath = `${this.resolvedOutputDir}/${file}`;
             const reportLog = readFileSync(reportLogPath).toString();
-            if (reportLog != ''){
+            if (reportLog) {
               runnerResult = JSON.parse(reportLog);
             }
           } catch (error) {


### PR DESCRIPTION
After implementing  a new feature to filter specs [AVOID STARTING SESSION FOR EXCLUDED SPECS](https://webdriver.io/blog/2019/11/01/spec-filtering.html) into our WebdriverIO suite, we start getting this error for every test that was skipped

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at Array.from.filter.forEach.file (/Users/dsch-web-tests/node_modules/wdio-timeline-reporter/build/timeline-service.js:136:45)
    at Array.forEach (<anonymous>)
    at TimelineService.onComplete (/Users/dsch-web-tests/node_modules/wdio-timeline-reporter/build/timeline-service.js:127:18)
    at Promise.all.launcher.map.service (/Users/dsch-web-tests/node_modules/@wdio/cli/build/utils.js:51:33)
    at Array.map (<anonymous>)
    at runServiceHook (/Users/dsch-web-tests/node_modules/@wdio/cli/build/utils.js:49:39)
    at Launcher.run (/Users/dsch-web-tests/node_modules/@wdio/cli/build/launcher.js:78:40)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

So the PR just adds a small validation, so that if the data for the test is empty, just ignore it.

Please let me know if there is a better approach to avoid this issue :)