### PR TITLE
Use relative path for image "src" in HTML report instead of absolute

### DIFF
--- a/lib/components/images-container.tsx
+++ b/lib/components/images-container.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import fs from 'fs';
+import { basename } from 'path';
 
 const makeImageSource = (path, embed) => {
   if (embed) {
@@ -11,7 +12,7 @@ const makeImageSource = (path, embed) => {
       //do nothing
     }
   }
-  return path;
+  return `./${basename(path)}`;
 };
 
 const ImagesContainer = props => {


### PR DESCRIPTION
Issue:
Set "embedImages" to false and copy result folder which have both image and HTML included to somewhere else. After that the HTML can't show the image at all. The reason is the image "src" uses
absolute path. The path works on the report generated path, but it does not work if the original path changed.

Solution:
Since the image file and HTML report file are at the same directory, the relateive path can be used to fix this issue.