### PR TITLE
fix#39: Screenshots are always created

### DIFF
--- a/lib/timeline-reporter.ts
+++ b/lib/timeline-reporter.ts
@@ -69,6 +69,7 @@ class TimelineReporter extends WDIOReporter {
 
   onAfterCommand(command) {
     if (
+      this.reporterOptions.screenshotStrategy!== 'none' &&
       command.endpoint.includes('screenshot') &&
       command.result &&
       command.result.value &&


### PR DESCRIPTION
Issue: 
https://github.com/QualityOps/wdio-timeline-reporter/issues/39

Dependency:
wdio-video-reporter

Description:
When the video reporter is present, the need for screenshot on:error and before:click becomes redundant, so if the users want to have html report and video reporter together, they should have an option to disable taking screenshot, which would be met by setting the strategy as none.