### PR TITLE
Fix for afterTest Hook - test.passed to passed

### DIFF
--- a/lib/timeline-service.ts
+++ b/lib/timeline-service.ts
@@ -107,12 +107,12 @@ export class TimelineService {
     }
   }
 
-  afterTest(test) {
+  afterTest(test,{passed}) {
     const { screenshotStrategy } = this.reporterOptions;
     if (screenshotStrategy === BEFORE_CLICK) {
       browser.takeScreenshot();
     }
-    if (screenshotStrategy === ON_ERROR && !test.passed) {
+    if (screenshotStrategy === ON_ERROR && !passed) {
       browser.takeScreenshot();
     }
   }


### PR DESCRIPTION
test.passed is always undefined as there is no such property
condition should be checking for passed property
This was causing unnecessary screenshot after each test.