### PR TITLE
Feature: Add RDT support

### DIFF
--- a/lib/components/specs-results.tsx
+++ b/lib/components/specs-results.tsx
@@ -3,9 +3,23 @@ import SuiteResults from './suites-results';
 import humanizeDuration from 'humanize-duration';
 import { getBrowserFontIconClass } from './test-summary';
 
+const getBrowserNameAndCombo = (capabilities) => {
+    const name =
+      capabilities.browserName ||
+      capabilities.deviceName ||
+      'unknown browser name';
+    const version =
+      capabilities.browserVersion ||
+      capabilities.platformVersion ||
+      capabilities.version ||
+      'unknown browser version';
+    return `${name} ${version}`;
+  }
+
 const SpecsResults = props => {
   const { specs } = props;
   return specs.map(spec => {
+    const {capabilities: {browserName, platformName, platformVersion, deviceModel, deviceManufacturer}} = spec;
     return (
       <div className="box" data-box-is="spec">
         <h4 className="title is-4">
@@ -15,11 +29,19 @@ const SpecsResults = props => {
           <span className="has-text-grey-light">Duration:</span>{' '}
           {humanizeDuration(spec.duration, { round: true })}
         </h4>
+        {platformName && <h4 className="title is-4">
+          <span className="has-text-grey-light">Platform: </span>
+          {platformVersion ? `${platformName} ${platformVersion}`: platformName}
+        </h4>}
+        {deviceModel && deviceManufacturer && <h4 className="title is-4">
+          <span className="has-text-grey-light">Model: </span>
+          {`${deviceManufacturer}: ${deviceModel}`}
+        </h4>}
         <h4 className="title is-4">
           <span className="has-text-grey-light">Browser: </span>
           <span className="has-text-grey-light">
-            <i className={`fab ${getBrowserFontIconClass(spec.browser)}`} />
-          </span> {spec.browser}
+            <i className={`fab ${getBrowserFontIconClass(browserName)}`} />
+          </span> {getBrowserNameAndCombo(spec.capabilities)}
         </h4>
         <SuiteResults suites={spec.suites} />
       </div>

--- a/lib/timeline-service.ts
+++ b/lib/timeline-service.ts
@@ -205,19 +205,6 @@ export class TimelineService {
     }
   }
 
-  getBrowserNameAndCombo(capabilities) {
-    const name =
-      capabilities.browserName ||
-      capabilities.deviceName ||
-      'unknown browser name';
-    const version =
-      capabilities.browserVersion ||
-      capabilities.platformVersion ||
-      capabilities.version ||
-      'unknown browser version';
-    return `${name} ${version}`;
-  }
-
   generateTestResults(results) {
     this.stopTime = Date.now();
     const passed = results.reduce(
@@ -251,14 +238,14 @@ export class TimelineService {
         end: result.end,
         duration: result.duration,
         filename: result.specs[0],
-        browser: this.getBrowserNameAndCombo(result.capabilities),
+        capabilities: result.capabilities,
         suites: result.suites.map(suite => ({
           title: suite.title,
           duration: suite.duration,
           start: suite.start,
           end: suite.end,
           tests: suite.tests.map(test => ({
-            browser: this.getBrowserNameAndCombo(result.capabilities),
+            capabilities: result.capabilities,
             title: test.title,
             start: test.start,
             end: test.end,


### PR DESCRIPTION
Context: 
In order to differentiate between a spec running against a real device vs desktop browser we need to allow real device data to be shown on the spec results component.

Changes:
- Contract between service and component has been updated, capabilities are now passed directly down into the component.
- Component utilizes the capabilities object to render Platform and Model data if present.