### PR TITLE
fix(doc): updated readme.md file with correct WDIO installation page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Because we spend a lot of time debugging failing tests switching from terminal o
 
 An example html report can be found [here](http://htmlpreview.github.io/?https://github.com/QualityOps/wdio-timeline-reporter/blob/master/images/example-timeline-report.html)
 
-Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/guide/getstarted/install.html).
+Instructions on how to install `WebdriverIO` can be found [here](https://webdriver.io/docs/gettingstarted).
 
 ## Installation
 


### PR DESCRIPTION
updated readme.md file with correct WDIO installation page URL. that is https://webdriver.io/docs/gettingstarted.

<img width="1018" alt="Screen Shot 2022-12-16 at 2 10 40 PM" src="https://user-images.githubusercontent.com/8421048/208171576-d95fb091-f481-4a8f-8537-0d0fb0e0b230.png">
